### PR TITLE
add to group without changing user group

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -13,7 +13,7 @@ PACKER_VERSION="0.10.2"
 apt-get update
 apt-get -y install docker.io ansible unzip
 # add docker privileges
-usermod -G docker ubuntu
+usermod -aG docker ubuntu
 # install pip
 pip install -U pip && pip3 install -U pip
 if [[ $? == 127 ]]; then


### PR DESCRIPTION
add the user to the docker group instead of changing the group to docker. 
otherwise user will loose sudo permissions.