### PR TITLE
Aws version updates

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -7,6 +7,8 @@ fi
 
 TERRAFORM_VERSION="0.11.7"
 PACKER_VERSION="1.2.4"
+AWS_EB_CLI="3.12.0"
+
 # create new ssh key
 [[ ! -f /home/ubuntu/.ssh/mykey ]] \
 && mkdir -p /home/ubuntu/.ssh \
@@ -31,8 +33,8 @@ if [[ $? == 127 ]]; then
     python3 get-pip.py
 fi
 # install awscli and ebcli
-pip install -U awscli
-pip install -U awsebcli
+pip install awsebcli==${AWS_EB_CLI} 
+pip install awscli --upgrade
 
 #terraform
 T_VERSION=$(/usr/local/bin/terraform -v | head -1 | cut -d ' ' -f 2 | tail -c +2)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -5,7 +5,7 @@ if [ -e /etc/redhat-release ] ; then
   REDHAT_BASED=true
 fi
 
-TERRAFORM_VERSION="0.11.7"
+TERRAFORM_VERSION="0.11.8"
 PACKER_VERSION="1.2.4"
 AWS_EB_CLI="3.12.0"
 


### PR DESCRIPTION
Updated the AWS EB CLI to a fixed version of 3.12.0. Updated AWS CLI to include --upgrade option
Versions of EB CLI > 3.12 produced this error when provisioned with vagrant and the install.ssh: devops-box: docker 3.5.0 has requirement requests!=2.18.0,>=2.14.2, but you'll have requests 2.9.1 which is incompatible.
When I Vagrant ssh'ed into machine could not access aws or eb from the command line. It appeared these installs failed due to incompatibilities.
There is likely a better long term fix but I haven't had luck yet.
Appreciate any feedback or thoughts! Thanks for sharing this repo!